### PR TITLE
Fix/issue 14 invalid entity

### DIFF
--- a/custom_components/traeger/__init__.py
+++ b/custom_components/traeger/__init__.py
@@ -27,7 +27,7 @@ PLATFORMS: Final[list[Platform]] = [
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Traeger from a config entry."""
-    _LOGGER.debug("Starting Traeger setup for entry: {entry.entry_id}")
+    _LOGGER.debug(f"Starting Traeger setup for entry: {entry.entry_id}")
 
     # Create client (your original sequence)
     session = async_get_clientsession(hass)
@@ -71,7 +71,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def _start(_: object | None = None) -> None:
         """Start cloud/MQTT in background on HA loop."""
         hass.async_create_background_task(
-            client.start(), name="{DOMAIN}_client_start", eager_start=True
+            client.start(), name=f"{DOMAIN}_client_start", eager_start=True
         )
 
     if hass.is_running:
@@ -80,25 +80,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.async_on_unload(hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _start))
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    _LOGGER.debug("Forwarded setup for platforms: {PLATFORMS}")
+    _LOGGER.debug(f"Forwarded setup for platforms: {PLATFORMS}")
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    _LOGGER.debug("Unloading Traeger integration for entry: {entry.entry_id}")
+    _LOGGER.debug(f"Unloading Traeger integration for entry: {entry.entry_id}")
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         data = hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
         client = data and data.get("client")
         if client and hasattr(client, "kill"):
             await client.kill()
-    _LOGGER.debug("Unloaded Traeger integration for entry: {entry.entry_id}, unload_ok={unload_ok}")
+    _LOGGER.debug(f"Unloaded Traeger integration for entry: {entry.entry_id}, unload_ok={unload_ok}")
     return unload_ok
 
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload config entry."""
-    _LOGGER.debug("Reloading Traeger integration for entry: {entry.entry_id}")
+    _LOGGER.debug(f"Reloading Traeger integration for entry: {entry.entry_id}")
     await async_unload_entry(hass, entry)
     await async_setup_entry(hass, entry)

--- a/custom_components/traeger/climate.py
+++ b/custom_components/traeger/climate.py
@@ -11,6 +11,7 @@ from homeassistant.components.climate import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
+from homeassistant.util import slugify
 
 from .const import (
     DOMAIN,
@@ -89,10 +90,10 @@ class TraegerGrill(ClimateEntity, TraegerBaseEntity):
 
     def __init__(self, client, grill_id: str, *, coordinator=None) -> None:
         super().__init__(client, grill_id, name="Grill Climate", coordinator=coordinator)
-        self._attr_unique_id = "{grill_id}_climate"
-        self.entity_id = "climate.{slugify(grill_id)}_climate"
+        self._attr_unique_id = f"{grill_id}_climate"
+        self.entity_id = f"climate.{slugify(grill_id)}_climate"
         self._attr_entity_registry_visible_default = True
-        _LOGGER.debug("Initialized climate {self.entity_id} for grill {grill_id}")
+        _LOGGER.debug(f"Initialized climate {self.entity_id} for grill {grill_id}")
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
@@ -183,7 +184,7 @@ class TraegerGrill(ClimateEntity, TraegerBaseEntity):
         else:
             await self.client.shutdown_grill(self.grill_id)
         if hasattr(self.client, "trigger_mqtt_refresh"):
-            _LOGGER.debug("Requesting MQTT poke after hvac_mode change for {self.entity_id}")
+            _LOGGER.debug(f"Requesting MQTT poke after hvac_mode change for {self.entity_id}")
             await self.client.trigger_mqtt_refresh(self.grill_id)
         self.async_schedule_update_ha_state()
 
@@ -192,7 +193,7 @@ class TraegerGrill(ClimateEntity, TraegerBaseEntity):
         if temperature is not None:
             await self.client.set_temperature(self.grill_id, int(temperature))
             if hasattr(self.client, "trigger_mqtt_refresh"):
-                _LOGGER.debug("Requesting MQTT poke after target temp change for {self.entity_id}")
+                _LOGGER.debug(f"Requesting MQTT poke after target temp change for {self.entity_id}")
                 await self.client.trigger_mqtt_refresh(self.grill_id)
             self.async_schedule_update_ha_state()
 
@@ -205,13 +206,13 @@ class TraegerGrillProbe(ClimateEntity, TraegerBaseEntity):
     """Climate entity for a grill probe."""
 
     def __init__(self, client, grill_id: str, channel: str, *, coordinator=None) -> None:
-        super().__init__(client, grill_id, name="Probe {channel}", coordinator=coordinator)
+        super().__init__(client, grill_id, name=f"Probe {channel}", coordinator=coordinator)
         self._channel = channel
         self.accessory_id = channel
-        self._attr_unique_id = "{grill_id}_probe_{channel}"
-        self.entity_id = "climate.{slugify(grill_id)}_probe_{slugify(channel)}"
+        self._attr_unique_id = f"{grill_id}_probe_{channel}"
+        self.entity_id = f"climate.{slugify(grill_id)}_probe_{slugify(channel)}"
         self._attr_entity_registry_visible_default = True
-        _LOGGER.debug("Initialized probe {self.entity_id} for grill {grill_id}")
+        _LOGGER.debug(f"Initialized probe {self.entity_id} for grill {grill_id}")
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()

--- a/custom_components/traeger/monitor.py
+++ b/custom_components/traeger/monitor.py
@@ -58,7 +58,7 @@ class TraegerGrillMonitor:
             channel = acc.get("uuid") or acc.get("channel")
             if not channel or not isinstance(channel, str):
                 _LOGGER.debug(
-                    "Skipping accessory with missing/invalid channel on grill {self.grill_id}: {acc}"
+                    f"Skipping accessory with missing/invalid channel on grill {self.grill_id}: {acc}"
                 )
                 continue
             if channel in self._seen_channels:
@@ -82,14 +82,14 @@ class TraegerGrillMonitor:
         for channel in self._iter_new_channels(state):
             entity = self._make_entity(channel)
             _LOGGER.debug(
-                "Discovered {self.entity_class.__name__} on grill {self.grill_id}: channel={channel}"
+                f"Discovered {self.entity_class.__name__} on grill {self.grill_id}: channel={channel}"
             )
             new_entities.append(entity)
             self._seen_channels.add(channel)
 
         if new_entities:
             _LOGGER.debug(
-                "Monitor for grill {self.grill_id} adding {len(new_entities)} entity(ies)"
+                f"Monitor for grill {self.grill_id} adding {len(new_entities)} entity(ies)"
             )
             self.async_add_entities(new_entities)
 
@@ -102,7 +102,7 @@ class TraegerGrillMonitor:
             added = self._add_new_from_state(state)
             if added:
                 _LOGGER.debug(
-                    "Monitor for grill {self.grill_id} added {added} new entity(ies) from coordinator update"
+                    f"Monitor for grill {self.grill_id} added {added} new entity(ies) from coordinator update"
                 )
         except Exception:  # Best-effort; never raise from callbacks
             _LOGGER.exception("Monitor update failed for grill {self.grill_id}")
@@ -110,7 +110,7 @@ class TraegerGrillMonitor:
     async def async_setup(self) -> None:
         """Discover accessories and add entities. Subscribe for future updates."""
         _LOGGER.debug(
-            "Setting up probe monitor for grill {self.grill_id} using {self.entity_class.__name__}"
+            f"Setting up probe monitor for grill {self.grill_id} using {self.entity_class.__name__}"
         )
 
         # Initial discovery from latest available state
@@ -121,7 +121,7 @@ class TraegerGrillMonitor:
         if self.coordinator and hasattr(self.coordinator, "async_add_listener"):
             self._unsub = self.coordinator.async_add_listener(self._on_coordinator_update)
             _LOGGER.debug(
-                "Probe monitor subscribed to coordinator updates for grill {self.grill_id}"
+                f"Probe monitor subscribed to coordinator updates for grill {self.grill_id}"
             )
 
     def shutdown(self) -> None:

--- a/custom_components/traeger/number.py
+++ b/custom_components/traeger/number.py
@@ -38,7 +38,7 @@ class TraegerNumber(TraegerBaseEntity, NumberEntity):
         self._attr_native_max_value = 1440  # 24 hours in minutes
         self._attr_native_step = 1
         self._attr_native_unit_of_measurement = "min"
-        _LOGGER.debug("Initialized number {self.entity_id} for grill {grill_id}")
+        _LOGGER.debug(f"Initialized number {self.entity_id} for grill {grill_id}")
 
     @property
     def icon(self):
@@ -70,7 +70,7 @@ class TraegerNumber(TraegerBaseEntity, NumberEntity):
     def native_value(self):
         state = self.client.get_state_for_device(self.grill_id)
         if not state or not state.get("status"):
-            _LOGGER.debug("No state data for {self.entity_id}: state={state}")
+            _LOGGER.debug(f"No state data for {self.entity_id}: state={state}")
             return None
         start = state.get("status", {}).get("cook_timer_start", 0)
         end = state.get("status", {}).get("cook_timer_end", 0)


### PR DESCRIPTION
This pull request closes #14 [Invalid entity ID: 'climate.{slugify(grill_id)}_climate'](https://github.com/johnvoipguy/Traeger-WiFire/issues/14 )

Several "templated" strings weren't actually using the templated syntax. This addresses all of those strings and the Home Assistant log should no longer show that warnings related to invalid entity ids etc.

