### PR TITLE
fix: report pellet level as unavailable when no sensor is connected

### DIFF
--- a/custom_components/traeger/sensor.py
+++ b/custom_components/traeger/sensor.py
@@ -478,6 +478,11 @@ class TraegerSensor(TraegerBaseEntity, SensorEntity):
             return state.get("usage", {}).get("error_stats", {}).get(self._key)
         if self._key in ["grill_clean_countdown", "grease_trap_clean_countdown"]:
             return state.get("usage", {}).get(self._key)
+        if self._key == "pellet_level":
+            features = state.get("features", {})
+            if not features.get("pellet_sensor_connected", 0):
+                return None
+            return state.get("status", {}).get("pellet_level")
         return state.get("status", {}).get(self._key)
 
 


### PR DESCRIPTION
## Problem

On grill models without a physical pellet hopper sensor (e.g. Pro 780), Traeger firmware always reports `pellet_level: 0` in the MQTT status payload as a sentinel value — not a real reading. This causes the Pellet Level entity in Home Assistant to permanently display **0%**, which is misleading because the entity appears functional but is silently reporting a hardcoded value.

## Root cause

The `TraegerSensor.native_value` for `pellet_level` falls through to the generic `state["status"]["pellet_level"]` return, which blindly returns `0` regardless of whether a sensor is physically present.

## Fix

Traeger firmware already exposes the answer: every MQTT payload includes a `features` block with `pellet_sensor_connected` (0 = no sensor, 1 = sensor present):

```json
"features": {
    "pellet_sensor_enabled": 1,
    "pellet_sensor_connected": 0
}
```

The fix checks this flag before returning a value:

```python
if self._key == "pellet_level":
    features = state.get("features", {})
    if not features.get("pellet_sensor_connected", 0):
        return None
    return state.get("status", {}).get("pellet_level")
```

- `pellet_sensor_connected = 0` → returns `None` → HA shows entity as **unavailable** (correct: no sensor hardware)
- `pellet_sensor_connected = 1` → returns the real percentage (correct: sensor present)

## Why this is better than checking `pellet_level == 0`

- Uses the grill's own capability reporting — no magic numbers
- Works correctly across all models (Pro, Ironwood, Timberline, etc.)
- Handles the case where someone adds the pellet sensor accessory to a Pro 780 later — it will automatically start reporting real data without any integration changes

## Tested on

- Pro 780 (serial E8EB1B11C814, firmware 02.02.05) — entity now shows `unavailable` instead of `0%` ✓